### PR TITLE
Fixed "npm run test" container not exiting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ before_install:
   - docker build -t stephengrinder/docker-react -f Dockerfile.dev .
 
 script:
-  - docker run stephengrinder/docker-react npm run test -- --coverage
+  - docker run -e CI=true stephengrinder/docker-react npm run test -- --coverage


### PR DESCRIPTION
There are some cases that adding "-- --coverage" does not make the container exit as we expect. Adding an environment variable of `CI=true` helps to solve this problem. I've come across others experiencing the same problem.
[https://stackoverflow.com/questions/55991641/npm-test-coverage-never-exits](url)